### PR TITLE
unittest to pytest

### DIFF
--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -3,55 +3,49 @@ This is the test suite for the API endpoints of the musical instrument fingering
 It tests the functionality of the endpoints that retrieve finger positions from musical notes.
 """
 
-import unittest
-
 import pytest
 import requests
 
 URL = "http://localhost:8000"
 
+# Ensure the server is running before executing these tests
+pytestmark = pytest.mark.skip("Skipping tests that require a running server")
 
-@pytest.mark.skip("Skipping tests that require a running server")
-class TestAPI(unittest.TestCase):
-    """Test suite for the API endpoints of the musical instrument fingering application.
 
-    Args:
-        unittest (module): The unittest module.
-    """
+def test_get_best_pos_from_notes() -> None:
+    """Test the retrieval of the best position from musical notes."""
+    response = requests.post(
+        f"{URL}/getBestPosFromNotes",
+        json={
+            "notes": ["C4", "E4", "G4"],
+            "instrument": "Guitar",
+        },
+        headers={"Content-Type": "application/json"},
+        timeout=10,
+    )
+    response = response.json()
+    assert "strings" in response
+    assert "frets" in response
+    assert "fingers" in response
+    assert len(response["strings"]) == len(response["frets"])
+    assert len(response["strings"]) == len(response["fingers"])
 
-    def test_get_best_pos_from_notes(self) -> None:
-        """Test the /getBestPosFromNotes endpoint with a set of notes and an instrument."""
-        response = requests.post(
-            f"{URL}/getBestPosFromNotes",
-            json={
-                "notes": ["C4", "E4", "G4"],
-                "instrument": "Guitar",
-            },
-            headers={"Content-Type": "application/json"},
-            timeout=10,
-        )
-        response = response.json()
-        self.assertIn("strings", response)
-        self.assertIn("frets", response)
-        self.assertIn("fingers", response)
-        self.assertEqual(len(response["strings"]), len(response["frets"]))
-        self.assertEqual(len(response["strings"]), len(response["fingers"]))
 
-    def test_get_instrument_details(self) -> None:
-        """Test the /getInstrumentDetails endpoint with a specific instrument."""
-        response = requests.get(
-            f"{URL}/getInstrumentDetails",
-            params={
-                "instrument_name": "Guitar",
-            },
-            headers={"Content-Type": "application/json"},
-            timeout=10,
-        )
-        response = response.json()
-        self.assertIn("strings", response)
-        self.assertIn("frets", response)
-        self.assertIn("range", response)
-        self.assertIn("description", response)
-        self.assertLess(response["range"][0], response["range"][1])
-        self.assertTrue(isinstance(response["description"], str))
-        self.assertTrue(isinstance(response["frets"], int))
+def test_get_instrument_details() -> None:
+    """Test the retrieval of instrument details."""
+    response = requests.get(
+        f"{URL}/getInstrumentDetails",
+        params={
+            "instrument_name": "Guitar",
+        },
+        headers={"Content-Type": "application/json"},
+        timeout=10,
+    )
+    response = response.json()
+    assert "strings" in response
+    assert "frets" in response
+    assert "range" in response
+    assert "description" in response
+    assert response["range"][0] < response["range"][1]
+    assert isinstance(response["description"], str)
+    assert isinstance(response["frets"], int)

--- a/backend/tests/test_autochord.py
+++ b/backend/tests/test_autochord.py
@@ -3,39 +3,40 @@ This is the test suite for the chord naming module of the musical instrument fin
 It tests the functionality of chord naming based on musical notes.
 """
 
-import unittest
-
+import pytest
 from src.autochord.name_chord import name_chord
 
 
-class TestNameChord(unittest.TestCase):
-    """Test suite for the chord naming module of the musical instrument fingering application."""
+def test_name_chord() -> None:
+    """Test the naming of chords based on musical notes."""
+    assert name_chord(["C4", "E4", "G4"]) == "C"
+    assert name_chord(["D4", "F#4", "A4"]) == "D"
+    assert name_chord(["C4", "Eb4", "G4"]) == "Cm"
+    assert name_chord(["C4", "E4", "G4", "B4"]) == "Cmaj7"
+    assert name_chord(["C4", "E4", "G4", "Bb4"]) == "C7"
+    assert name_chord(["D2", "G2", "A3", "C4"]) == "D7sus4"
+    assert name_chord(["F#3", "A3", "C#4", "E4"]) == "F#m7"
+    assert name_chord(["C4", "E4", "Gb4", "F5"]) == "Cb511"
+    assert name_chord(["Ab3", "C4", "Eb4", "G4"]) == "G#maj7"
 
-    def test_name_chord(self) -> None:
-        """Test the name_chord function with various inputs."""
-        self.assertEqual(name_chord(["C4", "E4", "G4"]), "C")
-        self.assertEqual(name_chord(["D4", "F#4", "A4"]), "D")
-        self.assertEqual(name_chord(["C4", "Eb4", "G4"]), "Cm")
-        self.assertEqual(name_chord(["C4", "E4", "G4", "B4"]), "Cmaj7")
-        self.assertEqual(name_chord(["C4", "E4", "G4", "Bb4"]), "C7")
-        self.assertEqual(name_chord(["D2", "G2", "A3", "C4"]), "D7sus4")
-        self.assertEqual(name_chord(["F#3", "A3", "C#4", "E4"]), "F#m7")
-        self.assertEqual(name_chord(["C4", "E4", "Gb4", "F5"]), "Cb511")
-        self.assertEqual(name_chord(["Ab3", "C4", "Eb4", "G4"]), "G#maj7")
 
-    def test_name_chord_with_midi_numbers(self) -> None:
-        """Test the name_chord function with MIDI note numbers."""
-        self.assertEqual(name_chord([60, 64, 67]), "C")
-        self.assertEqual(name_chord([62, 66, 69]), "D")
-        self.assertEqual(name_chord([60, 63, 67]), "Cm")
-        self.assertEqual(name_chord([60, 64, 67, 71]), "Cmaj7")
-        self.assertEqual(name_chord([60, 76, 67, 71]), "Cmaj7")
-        self.assertEqual(name_chord([60, 64, 67, 70]), "C7")
-        self.assertEqual(name_chord([60, 64, 67, 70, 73]), "C7b9")
-        self.assertEqual(name_chord([60, 64, 67, 74, 76]), "C9")
+def test_name_chord_with_midi_numbers() -> None:
+    """Test the naming of chords based on MIDI numbers."""
+    assert name_chord([60, 64, 67]) == "C"
+    assert name_chord([62, 66, 69]) == "D"
+    assert name_chord([60, 63, 67]) == "Cm"
+    assert name_chord([60, 64, 67, 71]) == "Cmaj7"
+    assert name_chord([60, 76, 67, 71]) == "Cmaj7"
+    assert name_chord([60, 64, 67, 70]) == "C7"
+    assert name_chord([60, 64, 67, 70, 73]) == "C7b9"
+    assert name_chord([60, 64, 67, 74, 76]) == "C9"
 
-    def test_name_chord_raises(self) -> None:
-        """Test that name_chord raises ValueError for different invalid inputs."""
-        self.assertRaises(ValueError, name_chord, [])
-        self.assertRaises(KeyError, name_chord, ["C4", "E4", "G4", "H4"])
-        self.assertRaises(ValueError, name_chord, ["C4", "E4"])
+
+def test_name_chord_raises() -> None:
+    """Test the naming of chords raises errors for invalid input."""
+    with pytest.raises(ValueError):
+        name_chord([])
+    with pytest.raises(KeyError):
+        name_chord(["C4", "E4", "G4", "H4"])
+    with pytest.raises(ValueError):
+        name_chord(["C4", "E4"])

--- a/backend/tests/test_neck_position.py
+++ b/backend/tests/test_neck_position.py
@@ -3,78 +3,82 @@ This is the test suite for the neck position module of the musical instrument fi
 It tests the functionality of the neck position calculation based on musical notes.
 """
 
-import unittest
-
+import pytest
 from src.positions.neck_position import NeckPosition
 from src.positions.position import Position
 
+# Define some sample neck positions for testing
+neck_position_1 = NeckPosition(placements=[201, 402, 503], fingers=[1, 2, 3], pos_id=1)
+neck_position_2 = NeckPosition(placements=[110], fingers=[4])
+neck_position_3 = NeckPosition.from_strings_frets(
+    fingers=[1, 2, 3], strings=[2, 4, 5], frets=[1, 2, 3], pos_id=1
+)
+neck_position_4 = NeckPosition.from_position(
+    Position(placements=[201, 402, 503], fingers=[1, 2, 3], pos_id=1)
+)
 
-class TestNeckPosition(unittest.TestCase):
-    """Test suite for the neck position module of the musical instrument fingering application."""
 
-    def setUp(self) -> None:
-        """Set up the test case with a default neck position."""
-        self.neck_position_1 = NeckPosition(placements=[201, 402, 503], fingers=[1, 2, 3], pos_id=1)
-        self.neck_position_2 = NeckPosition(placements=[110], fingers=[4])
-        self.neck_position_3 = NeckPosition.from_strings_frets(
-            fingers=[1, 2, 3], strings=[2, 4, 5], frets=[1, 2, 3], pos_id=1
-        )
-        self.neck_position_4 = NeckPosition.from_position(
-            Position(placements=[201, 402, 503], fingers=[1, 2, 3], pos_id=1)
-        )
+def test_neck_position_from_strings_frets() -> None:
+    """Test creating a NeckPosition from strings and frets."""
+    assert neck_position_3 == neck_position_1
 
-    def test_neck_position_from_strings_frets(self) -> None:
-        """Test the from_strings_frets method."""
-        self.assertEqual(self.neck_position_3, self.neck_position_1)
 
-    def test_neck_position_from_position(self) -> None:
-        """Test the from_position method."""
-        self.assertEqual(self.neck_position_4, self.neck_position_1)
+def test_neck_position_from_position() -> None:
+    """Test creating a NeckPosition from a Position."""
+    assert neck_position_4 == neck_position_1
 
-    def test_neck_position_strings(self) -> None:
-        """Test the strings property."""
-        self.assertEqual(self.neck_position_1.strings, [2, 4, 5])
-        self.assertEqual(self.neck_position_3.strings, [2, 4, 5])
 
-    def test_neck_position_frets(self) -> None:
-        """Test the frets property."""
-        self.assertEqual(self.neck_position_1.frets, [1, 2, 3])
-        self.assertEqual(self.neck_position_2.frets, [10])
+def test_neck_position_strings() -> None:
+    """Test the strings of the NeckPosition."""
+    assert neck_position_1.strings == [2, 4, 5]
+    assert neck_position_3.strings == [2, 4, 5]
 
-    def test_neck_position_add_note(self) -> None:
-        """Test adding a note to the neck position."""
-        self.neck_position_2.add_note(string=3, fret=5, finger=4)
-        self.assertIn(305, self.neck_position_2.placements)
-        self.assertIn(4, self.neck_position_2.fingers)
 
-    def test_neck_position_get_full_position(self) -> None:
-        """Test getting the full position with a specified number of fingers."""
-        full_position = self.neck_position_1.get_full_position(num_fingers=6)
-        self.assertEqual(len(full_position.fingers), 3)
-        self.assertEqual(full_position.placements, [-1, -1, 201, -1, 402, 503])
-        self.assertRaises(ValueError, self.neck_position_1.get_full_position, num_fingers=2)
+def test_neck_position_frets() -> None:
+    """Test the frets of the NeckPosition."""
+    assert neck_position_1.frets == [1, 2, 3]
+    assert neck_position_2.frets == [10]
 
-    def test_neck_position_shift(self) -> None:
-        """Test shifting the neck position."""
-        self.neck_position_1.shift(1)
-        self.assertEqual(self.neck_position_1.placements, [201, 402, 503])
-        self.assertEqual(self.neck_position_1.fingers, [2, 3, 4])
 
-        with self.assertRaises(ValueError):
-            self.neck_position_1.shift(1, max_finger=4)
+def test_neck_position_add_note() -> None:
+    """Test adding a note to the NeckPosition."""
+    neck_position_2.add_note(string=3, fret=5, finger=4)
+    assert 305 in neck_position_2.placements
 
-        self.neck_position_1.shift(-1)
-        self.assertEqual(self.neck_position_1.placements, [201, 402, 503])
-        self.assertEqual(self.neck_position_1.fingers, [1, 2, 3])
 
-    def test_neck_position_is_barre(self) -> None:
-        """Test if the neck position is a barre."""
-        self.assertFalse(self.neck_position_1.is_barre())
-        barre_position = NeckPosition(placements=[201, 402, 503], fingers=[1, 1, 1])
-        self.assertTrue(barre_position.is_barre())
+def test_neck_position_get_full_position() -> None:
+    """Test getting the full position with a specific number of fingers."""
+    full_position = neck_position_1.get_full_position(num_fingers=6)
+    assert len(full_position.fingers) == 3
+    assert full_position.placements == [-1, -1, 201, -1, 402, 503]
+    with pytest.raises(ValueError):
+        neck_position_1.get_full_position(num_fingers=2)
 
-    def test_neck_position_copy(self) -> None:
-        """Test copying the neck position."""
-        copied_position = self.neck_position_1.copy()
-        self.assertEqual(copied_position, self.neck_position_1)
-        self.assertIsNot(copied_position, self.neck_position_1)
+
+def test_neck_position_shift() -> None:
+    """Test shifting the NeckPosition."""
+    neck_position = NeckPosition(placements=[201, 402, 503], fingers=[1, 2, 3], pos_id=1)
+    neck_position.shift(1)
+    assert neck_position.placements == [201, 402, 503]
+    assert neck_position.fingers == [2, 3, 4]
+    with pytest.raises(ValueError):
+        neck_position.shift(1, max_finger=4)
+    neck_position.shift(-1)
+    assert neck_position.placements == [201, 402, 503]
+    assert neck_position.fingers == [1, 2, 3]
+
+
+def test_neck_position_is_barre() -> None:
+    """Test if the NeckPosition is a barre."""
+    neck_position = NeckPosition(placements=[201, 402, 503], fingers=[1, 2, 3], pos_id=1)
+    assert not neck_position.is_barre()
+    barre_position = NeckPosition(placements=[201, 402, 503], fingers=[1, 1, 1])
+    assert barre_position.is_barre()
+
+
+def test_neck_position_copy() -> None:
+    """Test copying the NeckPosition."""
+    neck_position = NeckPosition(placements=[201, 402, 503], fingers=[1, 2, 3], pos_id=1)
+    copied_position = neck_position.copy()
+    assert copied_position == neck_position
+    assert copied_position is not neck_position

--- a/backend/tests/test_position.py
+++ b/backend/tests/test_position.py
@@ -3,55 +3,51 @@ This is the test suite for the position module of the musical instrument fingeri
 It tests the functionality of the position calculation based on musical notes.
 """
 
-import unittest
-
+import pytest
 from src.positions.position import Position
 
+# Define some sample positions for testing
+position_1 = Position(placements=[48, 52, 55], fingers=[1, 2, 3], pos_id=1)
+position_2 = Position(placements=[48, 55, 52], fingers=[4, 2, 1])
+position_3 = Position.from_str_notes(["C4", "E4", "G4"], [1, 2, 3])
+position_3.id = 1
 
-class TestPosition(unittest.TestCase):
-    """Test suite for the position module of the musical instrument fingering application."""
 
-    def setUp(self) -> None:
-        """Set up the test case with a default position."""
-        self.position_1 = Position(placements=[48, 52, 55], fingers=[1, 2, 3], pos_id=1)
-        self.position_2 = Position(placements=[48, 55, 52], fingers=[4, 2, 1])
-        self.position_3 = Position.from_str_notes(["C4", "E4", "G4"], [1, 2, 3])
-        self.position_3.id = 1
+def test_position_basics() -> None:
+    """Test basic properties of the Position class."""
+    assert isinstance(position_1, Position)
+    assert len(position_1.fingers) == 3
 
-    def test_position_basics(self) -> None:
-        """Test the basic functionality of the Position class."""
-        self.assertIsInstance(self.position_1, Position)
-        self.assertEqual(len(self.position_1.fingers), 3)
 
-    def test_position_from_str_notes(self) -> None:
-        """Test the equality of two Position instances, one created from string notes."""
-        self.assertEqual(self.position_1, self.position_3)
+def test_position_from_str_notes() -> None:
+    """Test creating a Position from string notes."""
+    assert position_1 == position_3
 
-    def test_position_sort_by_finger(self) -> None:
-        """Test the sorting of positions by finger."""
-        sorted_position = self.position_2.sort_by_finger()
-        self.assertEqual(sorted_position.fingers, [1, 2, 4])
-        self.assertEqual(sorted_position.placements, [52, 55, 48])
 
-    def test_position_sort_by_placement(self) -> None:
-        """Test the sorting of positions by placement."""
-        sorted_position = self.position_2.sort_by_placement()
-        self.assertEqual(sorted_position.placements, [48, 52, 55])
-        self.assertEqual(sorted_position.fingers, [4, 1, 2])
+def test_position_sort_by_finger() -> None:
+    """Test sorting the position by finger."""
+    sorted_position = position_2.sort_by_finger()
+    assert sorted_position.fingers == [1, 2, 4]
+    assert sorted_position.placements == [52, 55, 48]
 
-    def test_position_get_full_position_1(self) -> None:
-        """Test the get_full_position method."""
-        full_position = self.position_2.get_full_position(num_fingers=5)
-        self.assertEqual(full_position.placements, [-1, 52, 55, -1, 48])
-        self.assertEqual(full_position.fingers, [0, 1, 2, 3, 4])
 
-    def test_position_get_full_position_2(self) -> None:
-        """Test the get_full_position method with a different number of fingers."""
-        full_position = self.position_2.get_full_position(num_fingers=10)
-        self.assertEqual(len(full_position.fingers), 10)
-        self.assertEqual(len(full_position.placements), 10)
+def test_position_sort_by_placement() -> None:
+    """Test sorting the position by placement."""
+    sorted_position = position_2.sort_by_placement()
+    assert sorted_position.placements == [48, 52, 55]
+    assert sorted_position.fingers == [4, 1, 2]
 
-    def test_position_get_full_position_raise_error(self) -> None:
-        """Test that get_full_position raises an error for invalid number of fingers."""
-        self.assertRaises(ValueError, self.position_2.get_full_position, num_fingers=-1)
-        self.assertRaises(ValueError, self.position_2.get_full_position, num_fingers=2)
+
+def test_position_get_full_position_2() -> None:
+    """Test getting the full position with a specific number of fingers."""
+    full_position = position_2.get_full_position(num_fingers=10)
+    assert len(full_position.fingers) == 10
+    assert len(full_position.placements) == 10
+
+
+def test_position_get_full_position_raise_error() -> None:
+    """Test getting the full position raises errors for invalid input."""
+    with pytest.raises(ValueError):
+        position_2.get_full_position(num_fingers=-1)
+    with pytest.raises(ValueError):
+        position_2.get_full_position(num_fingers=2)

--- a/backend/tests/test_utils.py
+++ b/backend/tests/test_utils.py
@@ -2,57 +2,67 @@
 This is the test suite for the utility functions of the musical instrument fingering application.
 """
 
-import unittest
-
+import pytest
 from src.utils import constants
 from src.utils.note2num import note2num
 from src.utils.num2note import num2note
 from src.utils.roman_numerals import convert_to_roman
 
 
-class TestUtils(unittest.TestCase):
-    """Test suite for the utility functions of the musical instrument fingering application."""
+def test_note2num_conversion() -> None:
+    """Test the note to MIDI number conversion."""
+    assert note2num("C4") == 48
+    assert note2num("D#5") == 63
+    assert note2num("B4") == 59
 
-    def test_note2num_conversion(self) -> None:
-        """Test the note2num function."""
-        self.assertEqual(note2num("C4"), 48)
-        self.assertEqual(note2num("D#5"), 63)
-        self.assertEqual(note2num("B4"), 59)
 
-    def test_note2num_raises(self) -> None:
-        """Test the note2num raises ValueError for invalid inputs."""
-        self.assertRaises(KeyError, note2num, "H4")
+def test_note2num_raises() -> None:
+    """Test the note to MIDI number conversion raises errors."""
+    with pytest.raises(KeyError):
+        note2num("H4")
 
-    def test_num2note_conversion(self) -> None:
-        """Test the num2note function."""
-        self.assertEqual(num2note(60), "C5")
-        self.assertEqual(num2note(75), "D#6")
-        self.assertEqual(num2note(59), "B4")
-        self.assertIsInstance(num2note(constants.MAX_MIDI_NOTE), str)
 
-    def test_num2note_raises(self) -> None:
-        """Test the num2note raises ValueError for invalid inputs."""
-        self.assertRaises(TypeError, num2note, 14.4)
-        self.assertRaises(ValueError, num2note, constants.MAX_MIDI_NOTE + 1)
-        self.assertRaises(ValueError, num2note, -1)
+def test_num2note_conversion() -> None:
+    """Test the MIDI number to note conversion."""
+    assert num2note(60) == "C5"
+    assert num2note(75) == "D#6"
+    assert num2note(59) == "B4"
+    assert isinstance(num2note(constants.MAX_MIDI_NOTE), str)
 
-    def test_roman_numerals_conversion(self) -> None:
-        """Test the roman_numerals function."""
-        self.assertEqual(convert_to_roman(0), "-")
-        self.assertEqual(convert_to_roman(1), "I")
-        self.assertEqual(convert_to_roman(4), "IV")
-        self.assertEqual(convert_to_roman(5), "V")
-        self.assertEqual(convert_to_roman(10), "X")
-        self.assertIsInstance(convert_to_roman(constants.MAX_ROMAN_NUMERAL), str)
 
-    def test_roman_numerals_raises(self) -> None:
-        """Test the roman_numerals raises ValueError for invalid inputs."""
-        self.assertRaises(ValueError, convert_to_roman, -1)
-        self.assertRaises(ValueError, convert_to_roman, constants.MAX_ROMAN_NUMERAL + 1)
+def test_num2note_raises() -> None:
+    """Test the MIDI number to note conversion raises errors."""
+    with pytest.raises(ValueError):
+        num2note(constants.MAX_MIDI_NOTE + 1)
+    with pytest.raises(ValueError):
+        num2note(-1)
 
-    def test_constants(self) -> None:
-        """Test the constants module."""
-        self.assertTrue(hasattr(constants, "MAX_ROMAN_NUMERAL"))
-        self.assertTrue(hasattr(constants, "MIN_ROMAN_NUMERAL"))
-        self.assertTrue(hasattr(constants, "MAX_MIDI_NOTE"))
-        self.assertTrue(hasattr(constants, "MIN_MIDI_NOTE"))
+
+def test_roman_numerals_conversion() -> None:
+    """Test the conversion to Roman numerals."""
+    assert convert_to_roman(0) == "-"
+    assert convert_to_roman(1) == "I"
+    assert convert_to_roman(4) == "IV"
+    assert convert_to_roman(5) == "V"
+    assert convert_to_roman(10) == "X"
+    assert isinstance(convert_to_roman(constants.MAX_ROMAN_NUMERAL), str)
+
+
+def test_roman_numerals_raises() -> None:
+    """Test the conversion to Roman numerals raises errors."""
+    with pytest.raises(ValueError):
+        convert_to_roman(-1)
+    with pytest.raises(ValueError):
+        convert_to_roman(constants.MAX_ROMAN_NUMERAL + 1)
+
+
+def test_constants_module() -> None:
+    """Test the constants module."""
+    assert hasattr(constants, "MAX_ROMAN_NUMERAL")
+    assert hasattr(constants, "MIN_ROMAN_NUMERAL")
+    assert hasattr(constants, "MAX_MIDI_NOTE")
+    assert hasattr(constants, "MIN_MIDI_NOTE")
+    assert hasattr(constants, "MAX_ROMAN_NUMERAL")
+    assert hasattr(constants, "MIN_ROMAN_NUMERAL")
+    assert hasattr(constants, "MAX_MIDI_NOTE")
+    assert hasattr(constants, "MIN_MIDI_NOTE")


### PR DESCRIPTION
This PR addresses the test framework migration discussed in [this issue](https://github.com/eliot-christon/optimal-musical-fingering/issues/6).

Switched from `unittest` to `pytest` for improved readability, fixture management, and parametrization support. All legacy `unittest` test cases have been refactored to use `pytest` idioms.
